### PR TITLE
Milestone 2 Add kafka rest proxy producer

### DIFF
--- a/ProjectBreakdown.md
+++ b/ProjectBreakdown.md
@@ -39,7 +39,7 @@ the sole focus of this project is to showcase the different parts of Kafka, and 
 **When** a new event has arrived in the Kafka topic  
 **Then** the event is joined on the table ....?
 
-## Architecture  
+## Architecture - Kafka Consumers
 There are two classes in the server code that handle incoming messages from a Kafka topic: Line and Weather.  
 
 ### Line
@@ -90,13 +90,36 @@ These are all the preconditions for `python consumers/server.py` not crashing.
 1. "TURNSTILE_SUMMARY" topic exists
 
 
+## Architecture - Kafka Producers  
+
+### Weather class + REST Proxy  
+The Weather class is not a Kafka Producer.    
+It's written in vanilla Python and simply simulates old hardware.  
+The class sends weather events to the Kafka REST server in the form of POST requests.  
+The requests include both the payload, and the AVRO schema to read it with.  
+
+Kafka REST Proxy has all the client functionality required to parse the requests, create a new topic, and write the events to the topic.  
+
 ## Project milestones - completion
-- [x] Schema for turnstile event defined
-...
-- [ ] Correctly named Kafka topic exists for each station in the simulation/in the database  
-- [ ] Kafka REST Proxy creates and populates a topic with events containing {temperature, status}
-...
+1. Create Kafka Producers
+- [x] Properly defined schema for arrival events  
+- [x] Properly defined schema for turnstile events  
+- [x] Station producer implemented
+- [x] Correctly named Kafka topic exists for each station in the simulation/in the database  
+- [x] simulation.py is able to populate topics with arrival and turnstile events
+
+2. Configure Kafka REST Proxy Producer
+- [x] Kafka REST Proxy creates and populates a topic with events containing {temperature, status}
+
+3. Configure Kafka Connect
+
+4. Configure the Faust Stream Processor
+
+5. Configure the KSQL Table
 - [ ] KSQL aggregates turnstile events into `TURNSTILE_SUMMARY` for each station (+direction?)
+
+6. End-to-end success
+
 - [ ] Dashboard displays list of stations on the Blue line
 - [ ] Emitting new turnstile event causes dashboard to update
 - [ ] simulation.py works and doesn't crash after 1 minute

--- a/ProjectBreakdown.md
+++ b/ProjectBreakdown.md
@@ -85,9 +85,9 @@ Accepted topics are: `*org.chicago.cta.station*` and `TURNSTILE_SUMMARY`.
 
 ## `server.py` dependencies
 
-These are all the preconditions for `python consumers/server.py` not crashing.  
-
+These are the preconditions for `python consumers/server.py` not crashing.  
 1. "TURNSTILE_SUMMARY" topic exists
+2. Faust Streaming aggregation table exists
 
 
 ## Architecture - Kafka Producers  

--- a/consumers/server.py
+++ b/consumers/server.py
@@ -63,18 +63,18 @@ def run_server():
     # Build kafka consumers
     consumers = [
         KafkaConsumer(
-            "org.chicago.cta.weather.v1",
+            "obi.transport_optimization.weather_updates",
             weather_model.process_message,
             offset_earliest=True,
         ),
         KafkaConsumer(
-            "org.chicago.cta.stations.table.v1",
+            "obi.transport_optimization.chicago.cta.stations.table.v1",
             lines.process_message,
             offset_earliest=True,
             is_avro=False,
         ),
         KafkaConsumer(
-            "^org.chicago.cta.station.arrivals.",
+            "^obi.transport_optimization.arrivals.",
             lines.process_message,
             offset_earliest=True,
         ),

--- a/producers/models/schemas/weather_key.json
+++ b/producers/models/schemas/weather_key.json
@@ -1,5 +1,5 @@
 {
-  "namespace": "com.udacity",
+  "namespace": "obi.transport_optimization.weather_updates",
   "type": "record",
   "name": "weather.key",
   "fields": [

--- a/producers/models/schemas/weather_value.json
+++ b/producers/models/schemas/weather_value.json
@@ -1,3 +1,17 @@
 {
-  "TODO": "Complete this Schema! (Make sure to delete this Key/Value Pair!"
+  "type": "record",
+  "namespace": "obi.transport_optimization.weather_updates",
+  "name": "weather",
+  "fields": [
+    {
+      "name": "temperature",
+      "type": "float",
+      "default": 0.0
+    },
+    {
+      "name": "status",
+      "type": "string",
+      "default": ""
+    }
+  ]
 }

--- a/producers/models/weather.py
+++ b/producers/models/weather.py
@@ -7,12 +7,12 @@ import random
 import urllib.parse
 
 import requests
+from datetime import datetime as dt
 
 from models.producer import Producer
 
 
 logger = logging.getLogger(__name__)
-
 
 class Weather(Producer):
     """Defines a simulated weather model"""
@@ -30,16 +30,12 @@ class Weather(Producer):
     summer_months = set((6, 7, 8))
 
     def __init__(self, month):
-        #
-        #
-        # TODO: Complete the below by deciding on a topic name, number of partitions, and number of
-        # replicas
-        #
-        #
         super().__init__(
-            "weather", # TODO: Come up with a better topic name
-            key_schema=Weather.key_schema,
-            value_schema=Weather.value_schema,
+            topic_name = f"obi.transport_optimization.weather_updates",
+            key_schema=None,
+            value_schema=None,
+            num_partitions=1,
+            num_replicas=1
         )
 
         self.status = Weather.status.sunny
@@ -53,9 +49,6 @@ class Weather(Producer):
             with open(f"{Path(__file__).parents[0]}/schemas/weather_key.json") as f:
                 Weather.key_schema = json.load(f)
 
-        #
-        # TODO: Define this value schema in `schemas/weather_value.json
-        #
         if Weather.value_schema is None:
             with open(f"{Path(__file__).parents[0]}/schemas/weather_value.json") as f:
                 Weather.value_schema = json.load(f)
@@ -72,38 +65,35 @@ class Weather(Producer):
 
     def run(self, month):
         self._set_weather(month)
-
+        a = dt.now()
+        timestamp = int(a.strftime('%Y%m%d'))
         #
         #
         # TODO: Complete the function by posting a weather event to REST Proxy. Make sure to
         # specify the Avro schemas and verify that you are using the correct Content-Type header.
         #
         #
-        logger.info("weather kafka proxy integration incomplete - skipping")
-        #resp = requests.post(
-        #    #
-        #    #
-        #    # TODO: What URL should be POSTed to?
-        #    #
-        #    #
-        #    f"{Weather.rest_proxy_url}/TODO",
-        #    #
-        #    #
-        #    # TODO: What Headers need to bet set?
-        #    #
-        #    #
-        #    headers={"Content-Type": "TODO"},
-        #    data=json.dumps(
-        #        {
-        #            #
-        #            #
-        #            # TODO: Provide key schema, value schema, and records
-        #            #
-        #            #
-        #        }
-        #    ),
-        #)
-        #resp.raise_for_status()
+        #logger.info("weather kafka proxy integration incomplete - skipping")
+        resp = requests.post(
+            f"{Weather.rest_proxy_url}/topics/{self.topic_name}",
+            headers={"Content-Type": "application/vnd.kafka.avro.v2+json"},
+            data=json.dumps(
+                {
+                     "key_schema": json.dumps(Weather.key_schema),
+                     "value_schema": json.dumps(Weather.value_schema),
+                     "records": [
+                         {
+                             "key": {"timestamp": int(timestamp)},
+                             "value": {
+                                 "temperature": float(self.temp),
+                                 "status": str(self.status.name)
+                             }
+                         }
+                     ]
+                }
+            ),
+        )
+        resp.raise_for_status()
 
         logger.debug(
             "sent weather data to kafka, temp: %s, status: %s",


### PR DESCRIPTION
**Milestone**
2. Create Kafka REST Proxy Producer

**This PR adds**:
• Avro schemas for weather update events 
• details of POST request that the weather hardware simulator needs to make to the REST proxy in order to create and populate a topic
• updated names of topics on the consumer server
• small documentation updates 

**Testing**
Previous PR required running `python simulation.py`.  
Same applies to this PR.  
Check the Kafka topics UI at `http://localhost:8085` to see if your topic gets correctly created and populated.  
Docker output logs can help with debugging any issues.  

**Notes**  
Figuring out the correct values to put in the POST request, as well as how to parse the Avro schema files with `json` can be tricky and hard to debug.  
The proxy server does not provide extremely informative responses (usually just `500` error).   
Avoid using the REST Proxy as much as possible, since it's a possible maintenance drag.  